### PR TITLE
Added flutter 1.7 compatibility for Android. Executing result.success in UI thread only.

### DIFF
--- a/android/src/main/kotlin/com/vanelizarov/flutter_image_utils/CallHandler.kt
+++ b/android/src/main/kotlin/com/vanelizarov/flutter_image_utils/CallHandler.kt
@@ -1,6 +1,8 @@
 package com.vanelizarov.flutter_image_utils
 
+import android.app.Activity
 import android.graphics.BitmapFactory
+import android.util.Log
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import java.util.concurrent.Executors
@@ -11,7 +13,7 @@ class CallHandler(var call: MethodCall, var result: MethodChannel.Result) {
         private val executor = Executors.newFixedThreadPool(5)
     }
 
-    fun handle() {
+    fun handle(activity: Activity) {
         executor.execute {
             when (call.method) {
                 "crop" -> {
@@ -27,9 +29,13 @@ class CallHandler(var call: MethodCall, var result: MethodChannel.Result) {
                         val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.count())
                         val exifRotation = Exif.getRotationDegrees(bytes)
 
-                        result.success(bitmap.crop(x, y, width, height, exifRotation).toByteArray(quality))
+                        activity.runOnUiThread(java.lang.Runnable {
+                            result.success(bitmap.crop(x, y, width, height, exifRotation).toByteArray(quality))
+                        })
                     } catch (e: Exception) {
-                        result.success(null)
+                        activity.runOnUiThread(java.lang.Runnable {
+                            result.success(null)
+                        })
                     }
                 }
 
@@ -43,9 +49,14 @@ class CallHandler(var call: MethodCall, var result: MethodChannel.Result) {
                         val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.count())
                         val exifRotation = Exif.getRotationDegrees(bytes)
 
-                        result.success(bitmap.rotate(angle + exifRotation).toByteArray(quality))
+                        activity.runOnUiThread(java.lang.Runnable {
+                            result.success(bitmap.rotate(angle + exifRotation).toByteArray(quality))
+                        })
+
                     } catch (e: Exception) {
-                        result.success(null)
+                        activity.runOnUiThread(java.lang.Runnable {
+                            result.success(null)
+                        })
                     }
                 }
 
@@ -60,9 +71,13 @@ class CallHandler(var call: MethodCall, var result: MethodChannel.Result) {
                         val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.count())
                         val exifRotation = Exif.getRotationDegrees(bytes)
 
-                        result.success(bitmap.resize(destWidth, destHeight, exifRotation).toByteArray(quality))
+                        activity.runOnUiThread(java.lang.Runnable {
+                            result.success(bitmap.resize(destWidth, destHeight, exifRotation).toByteArray(quality))
+                        })
                     } catch (e: Exception) {
-                        result.success(null)
+                        activity.runOnUiThread(java.lang.Runnable {
+                            result.success(null)
+                        })
                     }
                 }
 
@@ -76,9 +91,14 @@ class CallHandler(var call: MethodCall, var result: MethodChannel.Result) {
                         val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.count())
                         val exifRotation = Exif.getRotationDegrees(bytes)
 
-                        result.success(bitmap.resizeToMax(maxSize, exifRotation).toByteArray(quality))
+                        activity.runOnUiThread(java.lang.Runnable {
+                            result.success(bitmap.resizeToMax(maxSize, exifRotation).toByteArray(quality))
+                        })
                     } catch (e: Exception) {
-                        result.success(null)
+                        activity.runOnUiThread(java.lang.Runnable {
+                            result.success(null)
+                        })
+
                     }
                 }
             }

--- a/android/src/main/kotlin/com/vanelizarov/flutter_image_utils/FlutterImageUtilsPlugin.kt
+++ b/android/src/main/kotlin/com/vanelizarov/flutter_image_utils/FlutterImageUtilsPlugin.kt
@@ -1,21 +1,22 @@
 package com.vanelizarov.flutter_image_utils
 
+import android.app.Activity
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry.Registrar
 
-class FlutterImageUtilsPlugin: MethodCallHandler {
+class FlutterImageUtilsPlugin (val activity: Activity): MethodCallHandler {
   companion object {
     @JvmStatic
     fun registerWith(registrar: Registrar) {
       val channel = MethodChannel(registrar.messenger(), "flutter_image_utils")
-      channel.setMethodCallHandler(FlutterImageUtilsPlugin())
+      channel.setMethodCallHandler(FlutterImageUtilsPlugin(registrar.activity()))
     }
   }
 
   override fun onMethodCall(call: MethodCall, result: Result) {
-    CallHandler(call, result).handle()
+    CallHandler(call, result).handle(activity)
   }
 }


### PR DESCRIPTION
Plugin didnt worked in Android from flutter 1.7 stable update. I've fixed to call result.success in UI thread.